### PR TITLE
Fix for #419 - "Read more" link doesn't work in BorrowModal

### DIFF
--- a/help/en/components/BorrowModal.md
+++ b/help/en/components/BorrowModal.md
@@ -3,4 +3,4 @@ This dialog allows you to set your desired debt and collateral.
 If {debt} debt is reduced it will be deducted from {borrower}'s account.
 If {debt} debt is increased it will be credited to {borrower} provided there is sufficient {collateral} collateral.   
 
-Collateral may be added or removed so long as the minimal maintenance collateral is maintained. [Read more.](/#/help/dex/shorting)
+Collateral may be added or removed so long as the minimal maintenance collateral is maintained. [Read more.](dex/shorting)


### PR DESCRIPTION
![selection_214](https://cloud.githubusercontent.com/assets/201263/10872356/568cdda4-8100-11e5-98d8-bcdbb30bde3b.png)
