### PR TITLE
split localStorage.js into common and platform, provide browser platform module

### DIFF
--- a/dl/src/common/localStorage.js
+++ b/dl/src/common/localStorage.js
@@ -1,16 +1,17 @@
 // Localstorage
-var ls = typeof localStorage === "undefined" ? null : localStorage;
+import ls, {ls_key_exists} from './localStorageImpl';
 
-var STORAGE_KEY = null;
+if (null===ls) throw "localStorage is required but isn't available on this platform";
 
 module.exports = (key) => {
-    
-    STORAGE_KEY = key;
+
+    var STORAGE_KEY = key;
 
     return {
         get(key, dv = {}) {
+
             let rv;
-            if (ls && (STORAGE_KEY + key) in ls) {
+            if ( ls_key_exists(STORAGE_KEY + key, ls) ) {
                 rv = JSON.parse(ls.getItem(STORAGE_KEY + key));
             }
             return rv ? rv : dv;
@@ -20,25 +21,15 @@ module.exports = (key) => {
             if (object.toJS) {
                 object = object.toJS();
             }
-            if (ls) {
-                ls.setItem(STORAGE_KEY + key, JSON.stringify(object));
-            }
+            ls.setItem(STORAGE_KEY + key, JSON.stringify(object));
         },
 
         remove(key) {
-            if (ls) {
-                ls.removeItem(STORAGE_KEY + key);
-            }
+            ls.removeItem(STORAGE_KEY + key);
         },
 
         has(key) {
-            if (!ls) {
-                return false;
-            }
-
-            return key in ls;
+            return ls_key_exists(STORAGE_KEY + key, ls);
         }
-
-
     };
 }

--- a/dl/src/common/localStorageImpl.js
+++ b/dl/src/common/localStorageImpl.js
@@ -1,0 +1,3 @@
+var ls_key_exists = function _ls_key_exists(key,ls) { return (key in ls); }
+export {ls_key_exists};
+export default (typeof localStorage === "undefined" ? null : localStorage);


### PR DESCRIPTION
As promised, this factors out localStorage implementation into platform specific module. Additionally the function ls_key_exists(key,ls) is exported from the platform module, and `key in ls` checks in localStorage.js are replaced with that, because the `key in ls` syntax is probably unshimmable.
