### PR TITLE
Slight aesthetic improvements to the Total Balance Value tooltip

### DIFF
--- a/web/app/components/Utility/TotalBalanceValue.jsx
+++ b/web/app/components/Utility/TotalBalanceValue.jsx
@@ -200,13 +200,24 @@ class TotalValue extends React.Component {
             }
         });
 
+        // Determine if higher precision should be displayed
+        let hiPrec = false;
+        for (let asset in assetValues) {
+            if (assets[asset] && assetValues[asset]) {
+                if (Math.abs(utils.get_asset_amount(assetValues[asset], toAsset)) < 100) {
+                    hiPrec = true;
+                    break;
+                }
+            }
+        }
+
         let totalsTip = "<table><tbody>";
         for (let asset in assetValues) {
             if (assets[asset] && assetValues[asset]) {
                 let symbol = assets[asset].get("symbol");
                 let amount = utils.get_asset_amount(assetValues[asset], toAsset);
-                amount = utils.format_number(amount, Math.abs(amount) > 100 ? 0 : 2);
-                totalsTip = totalsTip += `<tr><td>${symbol}:&nbsp;</td><td style="text-align: right;">${amount} ${toAsset.get("symbol")}</td></tr>`;
+                amount = utils.format_number(amount, hiPrec ? 2 : 0);
+                totalsTip += `<tr><td>${symbol}:&nbsp;</td><td style="text-align: right;">${amount} ${toAsset.get("symbol")}</td></tr>`;
             }
         }
 

--- a/web/app/components/Utility/TotalBalanceValue.jsx
+++ b/web/app/components/Utility/TotalBalanceValue.jsx
@@ -211,15 +211,41 @@ class TotalValue extends React.Component {
             }
         }
 
+        // Render each asset's balance, noting if there are any values missing
+        const noDataSymbol = "**";
+        const minValue = 1e-12;
+        let missingData = false;
         let totalsTip = "<table><tbody>";
         for (let asset in assetValues) {
             if (assets[asset] && assetValues[asset]) {
                 let symbol = assets[asset].get("symbol");
                 let amount = utils.get_asset_amount(assetValues[asset], toAsset);
-                amount = utils.format_number(amount, hiPrec ? 2 : 0);
+                if (amount) {
+                    if (amount < minValue) { // really close to zero, but not zero, probably a result of incomplete data
+                        amount = noDataSymbol;
+                        missingData=true;
+                    } else if (hiPrec) {
+                        if (amount < 0.01)
+                            amount = "<0.01";
+                        else
+                            amount = utils.format_number(amount, 2);
+                    } else {
+                        if (amount < 1)
+                            amount = "<1";
+                        else
+                            amount = utils.format_number(amount, 0);
+                    }
+                } else {
+                    amount = noDataSymbol;
+                    missingData = true;
+                }
                 totalsTip += `<tr><td>${symbol}:&nbsp;</td><td style="text-align: right;">${amount} ${toAsset.get("symbol")}</td></tr>`;
             }
         }
+
+        // If any values are missing, let the user know.
+        if (missingData)
+            totalsTip += `<tr><td>&nbsp;</td><td style="text-align: right;">${noDataSymbol} no data</td></tr>`;
 
         totalsTip += "</tbody></table>"
         


### PR DESCRIPTION
- Aligns balances by forcing them all to have higher precision if any of them do.
- Indicates missing data (rather than claiming zero balance).
- Indicates when a balance's value is less than the precision of the preferred asset.
