### PR TITLE
Fixes a bug that caused the CLI wallet to be unable to decrypt memos

### DIFF
--- a/dl/src/ecc/key_private.coffee
+++ b/dl/src/ecc/key_private.coffee
@@ -24,12 +24,12 @@ class PrivateKey
         if buf.length is 0
             throw new Error "Empty buffer"
         new PrivateKey BigInteger.fromBuffer(buf)
-    
+
     PrivateKey.fromSeed = (seed) -> # generate_private_key
         unless typeof seed is 'string'
             throw new Error 'seed must be of type string'
         PrivateKey.fromBuffer hash.sha256 seed
-    
+
     PrivateKey.fromWif = (_private_wif) ->
         private_wif = new Buffer base58.decode _private_wif
         version = private_wif.readUInt8(0)
@@ -63,10 +63,10 @@ class PrivateKey
     toPublicKey: ->
         return @public_key if @public_key
         @public_key = PublicKey.fromPoint @toPublicKeyPoint()
-    
+
     toBuffer: ->
         @d.toBuffer(32)
-    
+
     ###* ECIES ###
     get_shared_secret:(public_key)->
         KB = public_key.toUncompressed().toBuffer()
@@ -78,22 +78,29 @@ class PrivateKey
         r = @toBuffer()
         P = KBP.multiply BigInteger.fromBuffer r
         S = P.affineX.toBuffer {size: 32}
+
+        # the input to sha512 must be exactly 32-bytes, to match the c++ implementation
+        # of get_shared_secret.  Right now S will be shorter if the most significant
+        # byte(s) is zero.  Pad it back to the full 32-bytes
+        if S.length < 32
+          pad = new Buffer(32 - S.length).fill(0)
+          S = Buffer.concat([pad, S])
         # SHA512 used in ECIES
         hash.sha512 S
-    
+
     ### <helper_functions> ###
-    
+
     toByteBuffer: () ->
         b = new ByteBuffer(ByteBuffer.DEFAULT_CAPACITY, ByteBuffer.LITTLE_ENDIAN)
         @appendByteBuffer(b)
         b.copy 0, b.offset
-    
+
     PrivateKey.fromHex = (hex) ->
         PrivateKey.fromBuffer new Buffer hex, 'hex'
 
     toHex: ->
         @toBuffer().toString 'hex'
-        
+
     ### </helper_functions> ###
 
 module.exports = PrivateKey


### PR DESCRIPTION
in some transactions sent by the web wallet, and vice versa.
The shared secret used in to encrypt the memos is derived by computing
a 256-bit quantity from the public and private keys.  When the high-
order byte of this quantity is zero, this implementation was omitting
the high-order byte, producing a 248-bit number instead.  When passed
through the hash function to create the symmetric key, this generated
a different key from the C++ implementation which always generates
256-bits.
This fix will restore compatibility with the CLI wallet, but will
prevent the web wallet from decoding any incompatible memos that were
have already been generated.

Some discussion here: https://bitsharestalk.org/index.php/topic,22477.0.html
