### PR TITLE
Allow internal conversions using BlockTrades bridge, minor fixes to gateway page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ nvm use v5
 
 On windows NVM (support node version 4 and up) work from here: https://github.com/coreybutler/nvm-windows
 ```
-nvm install v5.11.1 32
-nvm use v5.11.1
+nvm install 5.11.1 32
+nvm use 5.11.1
 ```
 Once you have Node installed, you can clone the repo:
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ nvm install v5
 nvm use v5
 ```
 
+On windows NVM (support node version 4 and up) work from here: https://github.com/coreybutler/nvm-windows
+```
+nvm install v5.11.1 32
+nvm use v5.11.1
+```
 Once you have Node installed, you can clone the repo:
 ```
 git clone https://github.com/cryptonomex/graphene-ui.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Graphene-UI
 Graphene-UI depends on Node.js. While it should work using versions as old as 0.12.x, it is recommended to use v5.x.
 
 On Ubuntu and OSX, the easiest way to install Node is to use the [Node Version Manager](https://github.com/creationix/nvm).
-For Windows users there is [NVM-Windows](https://github.com/coreybutler/nvm-windows).
 
 To install NVM for Linux/OSX, simply copy paste the following in a terminal:
 ```

--- a/web/app/assets/locales/locale-en.json
+++ b/web/app/assets/locales/locale-en.json
@@ -980,8 +980,7 @@
     },
     "convert": {
       "amount": "Amount to Convert",
-      "address": "Convert to Address",
-      "submit": "Get memo"
+      "submit": "Ok"
     },
     "settle": {
       "title": "Request settlement of %(asset)s",
@@ -1035,7 +1034,7 @@
     "generate_new": "Get new address",
     "deposit": "Deposit",
     "withdraw": "Withdrawal",
-	"convert": "Internal convertion",
+	"convert": "Internal conversion",
     "withdraw_now": "Withdraw now",
 	"convert_now": "Convert now",
     "inventory": "Inventory",

--- a/web/app/assets/locales/locale-en.json
+++ b/web/app/assets/locales/locale-en.json
@@ -1030,6 +1030,7 @@
     "generate_new": "Get new address",
     "deposit": "Deposit",
     "withdraw": "Withdrawal",
+	"convert": "Internal convertion",
     "withdraw_now": "Withdraw now",
     "inventory": "Inventory",
     "scan_qr": "Scan QR",

--- a/web/app/assets/locales/locale-en.json
+++ b/web/app/assets/locales/locale-en.json
@@ -978,6 +978,11 @@
       "amount": "Amount to Deposit",
       "submit": "Deposit"
     },
+    "convert": {
+      "amount": "Amount to Convert",
+      "address": "Convert to Address",
+      "submit": "Get memo"
+    },
     "settle": {
       "title": "Request settlement of %(asset)s",
       "amount": "Amount to settle",
@@ -1032,6 +1037,7 @@
     "withdraw": "Withdrawal",
 	"convert": "Internal convertion",
     "withdraw_now": "Withdraw now",
+	"convert_now": "Convert now",
     "inventory": "Inventory",
     "scan_qr": "Scan QR",
     "calc": "Calculating",
@@ -1052,6 +1058,7 @@
     "support_block": "For support, please contact Blocktrades at:",
     "valid_address": "Please enter a valid %(coin_type)s address",
     "withdraw_coin": "Withdraw %(coin)s (%(symbol)s)",
+	"convert_coin": "Convert to %(coin)s (%(symbol)s)",
     "limit": "Limit: %(amount)s %(symbol)s",
     "bridge_text": "A bridge lets you 'shapeshift' an asset into another one, for example BTC to BTS.",
     "gateway_text": "A gateway lets you move to and from Bitshares assets to the real asset, like OPEN.BTC to BTC.",

--- a/web/app/components/Account/AccountDepositWithdraw.jsx
+++ b/web/app/components/Account/AccountDepositWithdraw.jsx
@@ -240,6 +240,9 @@ class AccountDepositWithdraw extends React.Component {
                                 initial_withdraw_input_coin_type="bts"
                                 initial_withdraw_output_coin_type="btc"
                                 initial_withdraw_estimated_input_amount="100000"
+                                initial_conversion_input_coin_type="bts"
+                                initial_conversion_output_coin_type="bitbtc"
+                                initial_conversion_estimated_input_amount="1000"
                             /> : null}
 
                             {btService === "gateway" && blockTradesGatewayCoins.length ?

--- a/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -64,7 +64,6 @@ export default class BlockTradesGateway extends React.Component {
         this.setState({
             activeCoin: e.target.value
         });
-        console.log("Wha is this:", e.target.value);
 
         let setting = {};
         setting[`activeCoin_${this.props.provider}_${this.state.action}`] = e.target.value;

--- a/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -31,7 +31,7 @@ export default class BlockTradesGateway extends React.Component {
         super();
 
         this.state = {
-            activeCoin: this._getActiveCoin(props, {action: "deposit"}),
+            activeCoin: "BTC",
             action: "deposit"
         };
     }
@@ -64,6 +64,7 @@ export default class BlockTradesGateway extends React.Component {
         this.setState({
             activeCoin: e.target.value
         });
+        console.log("Wha is this:", e.target.value);
 
         let setting = {};
         setting[`activeCoin_${this.props.provider}_${this.state.action}`] = e.target.value;

--- a/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -31,7 +31,7 @@ export default class BlockTradesGateway extends React.Component {
         super();
 
         this.state = {
-            activeCoin: "BTC",
+            activeCoin: this._getActiveCoin(props, {action: "deposit"}),
             action: "deposit"
         };
     }

--- a/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
+++ b/web/app/components/DepositWithdraw/BlockTradesGateway.jsx
@@ -38,7 +38,20 @@ export default class BlockTradesGateway extends React.Component {
 
     _getActiveCoin(props, state) {
         let cachedCoin = props.viewSettings.get(`activeCoin_${props.provider}_${state.action}`, null);
-        let activeCoin = cachedCoin ? cachedCoin : props.coins.length ? props.coins[0][state.action === "withdraw" ? "symbol" : "backingCoinType"].toUpperCase() : null;
+		let firstTimeCoin = null;
+		if ((props.provider == 'blocktrades') && (state.action == 'deposit')) {
+			firstTimeCoin = 'BTC';
+		}
+		if ((props.provider == 'openledger') && (state.action == 'deposit')) {
+			firstTimeCoin = 'BTC';
+		}
+		if ((props.provider == 'blocktrades') && (state.action == 'withdraw')) {
+			firstTimeCoin = 'TRADE.BTC';
+		}
+		if ((props.provider == 'openledger') && (state.action == 'withdraw')) {
+			firstTimeCoin = 'OPEN.BTC';
+		}
+        let activeCoin = cachedCoin ? cachedCoin : firstTimeCoin;
         return activeCoin;
     }
 

--- a/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -264,7 +264,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             let withdraw_estimated_output_amount = this.getAndUpdateOutputEstimate("withdraw", withdraw_input_coin_type, withdraw_output_coin_type, this.state.withdraw_estimated_input_amount);
             let withdraw_limit = this.getCachedOrFreshDepositLimit("withdraw", withdraw_input_coin_type, withdraw_output_coin_type);
 			
-			let conversion_estimated_output_amount = this.getAndUpdateOutputEstimate("conversion", 'bts', 'bitbtc', '100000');
+			let conversion_estimated_output_amount = this.getAndUpdateOutputEstimate("conversion", conversion_input_coin_type, conversion_output_coin_type, this.state.conversion_estimated_input_amount);
 
             this.setState({
                 coin_info_request_state: this.coin_info_request_states.request_complete,
@@ -286,6 +286,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
 				conversion_output_coin_type: conversion_output_coin_type,
 				conversion_estimated_output_amount: conversion_estimated_output_amount,
                 withdraw_estimate_direction: this.estimation_directions.output_from_input,
+				conversion_estimate_direction: this.estimation_directions.output_from_input,
                 supports_output_memos: coins_by_type['btc'].supportsOutputMemos
             });
         })
@@ -329,6 +330,14 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             else
                 new_withdraw_estimated_input_amount = this.getAndUpdateinputEstimate("withdraw", this.state.withdraw_input_coin_type, this.state.withdraw_output_coin_type, new_withdraw_estimated_output_amount);
 
+            let new_conversion_estimated_input_amount = this.state.conversion_estimated_input_amount;
+            let new_conversion_estimated_output_amount = this.state.conversion_estimated_output_amount;
+			
+            if (this.state.conversion_estimate_direction == this.estimation_directions.output_from_input)
+                new_conversion_estimated_output_amount = this.getAndUpdateOutputEstimate("conversion", this.state.conversion_input_coin_type, this.state.conversion_output_coin_type, new_conversion_estimated_input_amount);
+            else
+                new_conversion_estimated_input_amount = this.getAndUpdateinputEstimate("conversion", this.state.conversion_input_coin_type, this.state.conversion_output_coin_type, new_conversion_estimated_output_amount);
+			
             this.setState(
             {
                 input_address_and_memo: new_input_address_and_memo,
@@ -337,7 +346,9 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                 deposit_estimated_output_amount: new_deposit_estimated_output_amount,
                 withdraw_limit: new_withdraw_limit,
                 withdraw_estimated_input_amount: new_withdraw_estimated_input_amount,
-                withdraw_estimated_output_amount: new_withdraw_estimated_output_amount
+                withdraw_estimated_output_amount: new_withdraw_estimated_output_amount,
+				conversion_estimated_input_amount: new_conversion_estimated_input_amount,
+				conversion_estimated_output_amount: new_conversion_estimated_output_amount
             });
         }
     }

--- a/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -451,7 +451,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
         this.state.deposit_limit_cache[input_coin_type][output_coin_type] = deposit_limit_record;
     }
 
-    getCachedOrFreshDepositLimit(deposit_or_withdraw, input_coin_type, output_coin_type)
+    getCachedOrFreshDepositLimit(deposit_withdraw_or_convert, input_coin_type, output_coin_type)
     {
         let deposit_limit_record = this.getCachedDepositLimit(input_coin_type, output_coin_type);
         if (deposit_limit_record)
@@ -479,16 +479,16 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             };
             this.cacheDepositLimit(input_coin_type, output_coin_type, new_deposit_limit_record);
             delete this.state.deposit_limit_requests_in_progress[input_coin_type][output_coin_type];
-            if (this.state[deposit_or_withdraw + "_input_coin_type"] == input_coin_type && 
-                this.state[deposit_or_withdraw + "_output_coin_type"] == output_coin_type)
-                this.setState({[deposit_or_withdraw + "_limit"]: new_deposit_limit_record});
+            if (this.state[deposit_withdraw_or_convert + "_input_coin_type"] == input_coin_type && 
+                this.state[deposit_withdraw_or_convert + "_output_coin_type"] == output_coin_type)
+                this.setState({[deposit_withdraw_or_convert + "_limit"]: new_deposit_limit_record});
         }, error => {
             delete this.state.deposit_limit_requests_in_progress[input_coin_type][output_coin_type];
         });
         return null;
     }
 
-    getAndUpdateOutputEstimate(deposit_or_withdraw, input_coin_type, output_coin_type, input_amount)
+    getAndUpdateOutputEstimate(deposit_withdraw_or_convert, input_coin_type, output_coin_type, input_amount)
     {
         let estimate_output_url = this.state.url + 
                                 "/estimate-output-amount?inputAmount=" + encodeURIComponent(input_amount) +
@@ -501,17 +501,17 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             // console.log("Reply: ", reply);
             if (reply.error)
             {
-                if (this.state[deposit_or_withdraw + "_input_coin_type"] == input_coin_type && 
-                    this.state[deposit_or_withdraw + "_output_coin_type"] == output_coin_type &&
-                    this.state[deposit_or_withdraw + "_estimated_input_amount"] == input_amount &&
-                    this.state[deposit_or_withdraw + "_estimate_direction"] == this.estimation_directions.output_from_input)
+                if (this.state[deposit_withdraw_or_convert + "_input_coin_type"] == input_coin_type && 
+                    this.state[deposit_withdraw_or_convert + "_output_coin_type"] == output_coin_type &&
+                    this.state[deposit_withdraw_or_convert + "_estimated_input_amount"] == input_amount &&
+                    this.state[deposit_withdraw_or_convert + "_estimate_direction"] == this.estimation_directions.output_from_input)
                 {
                     let user_message = reply.error.message;
                     let expected_prefix = "Internal Server Error: ";
                     if (user_message.startsWith(expected_prefix))
                         user_message = user_message.substr(expected_prefix.length);
 
-                    this.setState({[deposit_or_withdraw + "_error"]: user_message});
+                    this.setState({[deposit_withdraw_or_convert + "_error"]: user_message});
                 }
             }
             else
@@ -524,11 +524,11 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                     reply.outputCoinType != output_coin_type || 
                     reply.inputAmount != input_amount)
                     throw Error("unexpected reply from estimate-output-amount");
-                if (this.state[deposit_or_withdraw + "_input_coin_type"] == input_coin_type && 
-                    this.state[deposit_or_withdraw + "_output_coin_type"] == output_coin_type &&
-                    this.state[deposit_or_withdraw + "_estimated_input_amount"] == input_amount &&
-                    this.state[deposit_or_withdraw + "_estimate_direction"] == this.estimation_directions.output_from_input)
-                    this.setState({[deposit_or_withdraw + "_estimated_output_amount"]: reply.outputAmount, [deposit_or_withdraw + "_error"]: null});
+                if (this.state[deposit_withdraw_or_convert + "_input_coin_type"] == input_coin_type && 
+                    this.state[deposit_withdraw_or_convert + "_output_coin_type"] == output_coin_type &&
+                    this.state[deposit_withdraw_or_convert + "_estimated_input_amount"] == input_amount &&
+                    this.state[deposit_withdraw_or_convert + "_estimate_direction"] == this.estimation_directions.output_from_input)
+                    this.setState({[deposit_withdraw_or_convert + "_estimated_output_amount"]: reply.outputAmount, [deposit_withdraw_or_convert + "_error"]: null});
             }
         }, error => {
         });
@@ -536,7 +536,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
         return null;
     }
 
-    getAndUpdateInputEstimate(deposit_or_withdraw, input_coin_type, output_coin_type, output_amount)
+    getAndUpdateInputEstimate(deposit_withdraw_or_convert, input_coin_type, output_coin_type, output_amount)
     {
         let estimate_input_url = this.state.url + 
                                 "/estimate-input-amount?outputAmount=" + encodeURIComponent(output_amount) +
@@ -554,46 +554,46 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                 reply.outputCoinType != output_coin_type || 
                 reply.outputAmount != output_amount)
                 throw Error("unexpected reply from estimate-input-amount");
-            if (this.state[deposit_or_withdraw + "_input_coin_type"] == input_coin_type && 
-                this.state[deposit_or_withdraw + "_output_coin_type"] == output_coin_type &&
-                this.state[deposit_or_withdraw + "_estimated_output_amount"] == output_amount &&
-                this.state[deposit_or_withdraw + "_estimate_direction"] == this.estimation_directions.input_from_output)
-                this.setState({[deposit_or_withdraw + "_estimated_input_amount"]: reply.inputAmount});
+            if (this.state[deposit_withdraw_or_convert + "_input_coin_type"] == input_coin_type && 
+                this.state[deposit_withdraw_or_convert + "_output_coin_type"] == output_coin_type &&
+                this.state[deposit_withdraw_or_convert + "_estimated_output_amount"] == output_amount &&
+                this.state[deposit_withdraw_or_convert + "_estimate_direction"] == this.estimation_directions.input_from_output)
+                this.setState({[deposit_withdraw_or_convert + "_estimated_input_amount"]: reply.inputAmount});
         }, error => {
         });
 
         return null;
     }
 
-    onInputAmountChanged(deposit_or_withdraw, event)
+    onInputAmountChanged(deposit_withdraw_or_convert, event)
     {
         let new_estimated_input_amount = event.target.value;
-        let new_estimated_output_amount = this.getAndUpdateOutputEstimate(deposit_or_withdraw,
-                                                                          this.state[deposit_or_withdraw + "_input_coin_type"], 
-                                                                          this.state[deposit_or_withdraw + "_output_coin_type"], 
+        let new_estimated_output_amount = this.getAndUpdateOutputEstimate(deposit_withdraw_or_convert,
+                                                                          this.state[deposit_withdraw_or_convert + "_input_coin_type"], 
+                                                                          this.state[deposit_withdraw_or_convert + "_output_coin_type"], 
                                                                           new_estimated_input_amount);
 
         this.setState(
         {
-            [deposit_or_withdraw + "_estimated_input_amount"]: new_estimated_input_amount,
-            [deposit_or_withdraw + "_estimated_output_amount"]: new_estimated_output_amount,
-            [deposit_or_withdraw + "_estimate_direction"]: this.estimation_directions.output_from_input
+            [deposit_withdraw_or_convert + "_estimated_input_amount"]: new_estimated_input_amount,
+            [deposit_withdraw_or_convert + "_estimated_output_amount"]: new_estimated_output_amount,
+            [deposit_withdraw_or_convert + "_estimate_direction"]: this.estimation_directions.output_from_input
         });
     }
 
-    onOutputAmountChanged(deposit_or_withdraw, event)
+    onOutputAmountChanged(deposit_withdraw_or_convert, event)
     {
         let new_estimated_output_amount = event.target.value;
-        let new_estimated_input_amount = this.getAndUpdateInputEstimate(deposit_or_withdraw, 
-                                                                        this.state[deposit_or_withdraw + "_input_coin_type"], 
-                                                                        this.state[deposit_or_withdraw + "_output_coin_type"], 
+        let new_estimated_input_amount = this.getAndUpdateInputEstimate(deposit_withdraw_or_convert, 
+                                                                        this.state[deposit_withdraw_or_convert + "_input_coin_type"], 
+                                                                        this.state[deposit_withdraw_or_convert + "_output_coin_type"], 
                                                                         new_estimated_output_amount);
 
         this.setState(
         {
-            [deposit_or_withdraw + "_estimated_output_amount"]: new_estimated_output_amount,
-            [deposit_or_withdraw + "_estimated_input_amount"]: new_estimated_input_amount,
-            [deposit_or_withdraw + "_estimate_direction"]: this.estimation_directions.input_from_output
+            [deposit_withdraw_or_convert + "_estimated_output_amount"]: new_estimated_output_amount,
+            [deposit_withdraw_or_convert + "_estimated_input_amount"]: new_estimated_input_amount,
+            [deposit_withdraw_or_convert + "_estimate_direction"]: this.estimation_directions.input_from_output
         });
     }
 
@@ -606,21 +606,21 @@ class BlockTradesBridgeDepositRequest extends React.Component {
         ZfApi.publish(this.getWithdrawModalId(), "open");
     }
     
-    onInputCoinTypeChanged(deposit_or_withdraw, event)
+    onInputCoinTypeChanged(deposit_withdraw_or_convert, event)
     {
         let new_input_coin_type = event.target.value;
-        let possible_output_coin_types = this.state["allowed_mappings_for_" + deposit_or_withdraw][new_input_coin_type];
+        let possible_output_coin_types = this.state["allowed_mappings_for_" + deposit_withdraw_or_convert][new_input_coin_type];
         let new_output_coin_type = possible_output_coin_types[0];
-        if (possible_output_coin_types.indexOf(this.state[deposit_or_withdraw + "_output_coin_type"]) != -1)
-            new_output_coin_type = this.state[deposit_or_withdraw + "_output_coin_type"];
+        if (possible_output_coin_types.indexOf(this.state[deposit_withdraw_or_convert + "_output_coin_type"]) != -1)
+            new_output_coin_type = this.state[deposit_withdraw_or_convert + "_output_coin_type"];
 
         let new_input_address_and_memo = this.state.input_address_and_memo;
-        if (deposit_or_withdraw == "deposit")
+        if (deposit_withdraw_or_convert == "deposit")
             new_input_address_and_memo = this.getCachedOrGeneratedInputAddress(new_input_coin_type, new_output_coin_type);
-        let new_deposit_limit = this.getCachedOrFreshDepositLimit(deposit_or_withdraw, new_input_coin_type, new_output_coin_type);
-        let estimated_output_amount = this.getAndUpdateOutputEstimate(deposit_or_withdraw, new_input_coin_type, new_output_coin_type, this.state.deposit_estimated_input_amount);
+        let new_deposit_limit = this.getCachedOrFreshDepositLimit(deposit_withdraw_or_convert, new_input_coin_type, new_output_coin_type);
+        let estimated_output_amount = this.getAndUpdateOutputEstimate(deposit_withdraw_or_convert, new_input_coin_type, new_output_coin_type, this.state.deposit_estimated_input_amount);
 		
-		if (deposit_or_withdraw == "withdraw") {
+		if (deposit_withdraw_or_convert == "withdraw") {
 			possible_output_coin_types.forEach(allowed_withdraw_output_coin_type => {
 				if(new_output_coin_type===allowed_withdraw_output_coin_type){
 					this.setState({
@@ -633,21 +633,21 @@ class BlockTradesBridgeDepositRequest extends React.Component {
         
         this.setState(
         {
-            [deposit_or_withdraw + "_input_coin_type"]: new_input_coin_type,
-            [deposit_or_withdraw + "_output_coin_type"]: new_output_coin_type,
+            [deposit_withdraw_or_convert + "_input_coin_type"]: new_input_coin_type,
+            [deposit_withdraw_or_convert + "_output_coin_type"]: new_output_coin_type,
             input_address_and_memo: new_input_address_and_memo,
-            [deposit_or_withdraw + "_limit"]: new_deposit_limit,
-            [deposit_or_withdraw + "_estimated_output_amount"]: estimated_output_amount,
-            [deposit_or_withdraw + "_estimate_direction"]: this.estimation_directions.output_from_input
+            [deposit_withdraw_or_convert + "_limit"]: new_deposit_limit,
+            [deposit_withdraw_or_convert + "_estimated_output_amount"]: estimated_output_amount,
+            [deposit_withdraw_or_convert + "_estimate_direction"]: this.estimation_directions.output_from_input
         });
     }
     
-    onOutputCoinTypeChanged(deposit_or_withdraw, event)
+    onOutputCoinTypeChanged(deposit_withdraw_or_convert, event)
     {
         let new_output_coin_type = event.target.value;
 		let withdraw_output_coin_types = this.state.allowed_mappings_for_withdraw[this.state.withdraw_input_coin_type];
 	
-		if (deposit_or_withdraw == "withdraw") {
+		if (deposit_withdraw_or_convert == "withdraw") {
 			withdraw_output_coin_types.forEach(allowed_withdraw_output_coin_type => {
 				if(new_output_coin_type===allowed_withdraw_output_coin_type){
 					this.setState({
@@ -659,18 +659,18 @@ class BlockTradesBridgeDepositRequest extends React.Component {
 		}
 				
         let new_input_address_and_memo = this.state.input_address_and_memo;
-        if (deposit_or_withdraw == "deposit")
-            new_input_address_and_memo = this.getCachedOrGeneratedInputAddress(this.state[deposit_or_withdraw + "_input_coin_type"], new_output_coin_type);
-        let new_deposit_limit = this.getCachedOrFreshDepositLimit(deposit_or_withdraw, this.state[deposit_or_withdraw + "_input_coin_type"], new_output_coin_type);
-        let estimated_output_amount = this.getAndUpdateOutputEstimate(deposit_or_withdraw, this.state[deposit_or_withdraw + "_input_coin_type"], new_output_coin_type, this.state[deposit_or_withdraw + "_estimated_input_amount"]);
+        if (deposit_withdraw_or_convert == "deposit")
+            new_input_address_and_memo = this.getCachedOrGeneratedInputAddress(this.state[deposit_withdraw_or_convert + "_input_coin_type"], new_output_coin_type);
+        let new_deposit_limit = this.getCachedOrFreshDepositLimit(deposit_withdraw_or_convert, this.state[deposit_withdraw_or_convert + "_input_coin_type"], new_output_coin_type);
+        let estimated_output_amount = this.getAndUpdateOutputEstimate(deposit_withdraw_or_convert, this.state[deposit_withdraw_or_convert + "_input_coin_type"], new_output_coin_type, this.state[deposit_withdraw_or_convert + "_estimated_input_amount"]);
         
         this.setState(
         {
-            [deposit_or_withdraw + "_output_coin_type"]: new_output_coin_type,
+            [deposit_withdraw_or_convert + "_output_coin_type"]: new_output_coin_type,
             input_address_and_memo: new_input_address_and_memo,
-            [deposit_or_withdraw + "_limit"]: new_deposit_limit,
-            [deposit_or_withdraw + "_estimated_output_amount"]: estimated_output_amount,
-            [deposit_or_withdraw + "_estimate_direction"]: this.estimation_directions.output_from_input
+            [deposit_withdraw_or_convert + "_limit"]: new_deposit_limit,
+            [deposit_withdraw_or_convert + "_estimated_output_amount"]: estimated_output_amount,
+            [deposit_withdraw_or_convert + "_estimate_direction"]: this.estimation_directions.output_from_input
         });
     }
 

--- a/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -622,7 +622,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
     }
 	
     getConvertModalId() {
-        return "conversion_asset_" + this.props.gateway + "_bridge";
+        return "convert_asset_" + this.props.gateway + "_bridge";
     }
 
     onConvert() {
@@ -944,7 +944,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
 
             if (Object.getOwnPropertyNames(this.state.allowed_mappings_for_conversion).length > 0)
             {
-                conversion_modal_id = this.getConvertModalId('proba');
+                conversion_modal_id = this.getConvertModalId();
 
                 // conversion
                 let conversion_input_coin_type_options = [];
@@ -1066,16 +1066,14 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                         <div className="grid-block vertical">
                             <ConvertModalBlocktrades
 								key={`${this.state.coin_symbol}`}
-                                account={this.props.account.get('name')}
-                                issuer={this.props.issuer_account.get('name')}
+                                from_account={this.props.account.get('name')}
+								to_account={'blocktrades'}
                                 asset={this.state.coins_by_type[this.state.conversion_input_coin_type].walletSymbol}
                                 output_coin_name={this.state.coins_by_type[this.state.conversion_output_coin_type].name}
                                 output_coin_symbol={this.state.coins_by_type[this.state.conversion_output_coin_type].symbol}
-                                output_coin_type={this.state.conversion_output_coin_type}
 								conversion_memo={this.state.conversion_memo}
                                 modal_id={conversion_modal_id} 
-                                url={this.state.url}
-                                output_wallet_type={this.state.coins_by_type[this.state.conversion_output_coin_type].walletType} /> 
+                                url={this.state.url} /> 
                         </div>
                     </Modal>
                 </div>

--- a/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -24,7 +24,10 @@ class BlockTradesBridgeDepositRequest extends React.Component {
         initial_deposit_estimated_input_amount: React.PropTypes.string,
         initial_withdraw_input_coin_type: React.PropTypes.string,
         initial_withdraw_output_coin_type: React.PropTypes.string,
-        initial_withdraw_estimated_input_amount: React.PropTypes.string
+        initial_withdraw_estimated_input_amount: React.PropTypes.string,
+        initial_conversion_input_coin_type: React.PropTypes.string,
+        initial_conversion_output_coin_type: React.PropTypes.string,
+        initial_conversion_estimated_input_amount: React.PropTypes.string
     };
 
     constructor(props) {
@@ -70,11 +73,10 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             withdraw_error: null,
 			
 			// things that get displayed for conversions
-			conversion_input_coin_type: 'bts',
+			conversion_input_coin_type: null,
             conversion_output_coin_type: null,
-            conversion_estimated_input_amount: this.props.initial_withdraw_estimated_input_amount || "1.0",
+            conversion_estimated_input_amount: this.props.initial_conversion_estimated_input_amount || "1.0",
             conversion_estimated_output_amount: null,
-            conversion_limit: null,
             conversion_error: null,
 
             // input address-related
@@ -229,7 +231,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             
             let withdraw_input_coin_type = null;
             let withdraw_output_coin_type = null;
-			let conversion_input_coin_type = 'bts';
+			let conversion_input_coin_type = null;
 			let conversion_output_coin_type = null;
             let allowed_withdraw_coin_types = Object.keys(allowed_mappings_for_withdraw);
             allowed_withdraw_coin_types.forEach(withdraw_coin_type => { allowed_mappings_for_withdraw[withdraw_coin_type].sort(); });
@@ -254,7 +256,17 @@ class BlockTradesBridgeDepositRequest extends React.Component {
 			
             if (allowed_conversion_coin_types.length)
             {
-                conversion_output_coin_type = allowed_mappings_for_conversion[conversion_input_coin_type][0];
+                if (this.props.initial_conversion_input_coin_type &&
+                    this.props.initial_conversion_input_coin_type in allowed_mappings_for_conversion)
+                    conversion_input_coin_type = this.props.initial_conversion_input_coin_type;
+                else
+                    conversion_input_coin_type = allowed_conversion_coin_types[0];
+                let output_coin_types_for_this_input = allowed_mappings_for_conversion[conversion_input_coin_type];
+                if (this.props.initial_conversion_output_coin_type &&
+                    output_coin_types_for_this_input.indexOf(this.props.initial_conversion_output_coin_type) != -1)
+                    conversion_output_coin_type = this.props.initial_conversion_output_coin_type;
+                else
+                    conversion_output_coin_type = output_coin_types_for_this_input[0];
             }
             
             let input_address_and_memo = this.getCachedOrGeneratedInputAddress(deposit_input_coin_type, deposit_output_coin_type);

--- a/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/BlockTradesBridgeDepositRequest.jsx
@@ -61,7 +61,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
             deposit_limit: null,
             deposit_error: null,
 			
-            // things that get displayed for withdraws
+            // things that get displayed for withdrawals
             withdraw_input_coin_type: null,
             withdraw_output_coin_type: null,
             withdraw_estimated_input_amount: this.props.initial_withdraw_estimated_input_amount || "1.0",
@@ -919,7 +919,7 @@ class BlockTradesBridgeDepositRequest extends React.Component {
                 conversion_header =
                 <thead>
                     <tr>
-                        <th><Translate content="gateway.withdraw" /></th>
+                        <th><Translate content="gateway.convert" /></th>
                         <th ><Translate content="gateway.balance" /></th>
                         <th ></th>
                     </tr>

--- a/web/app/components/DepositWithdraw/blocktrades/BlockTradesGatewayDepositRequest.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/BlockTradesGatewayDepositRequest.jsx
@@ -247,12 +247,11 @@ export default class BlockTradesGatewayDepositRequest extends React.Component {
                             <table className="table">
                                 <tbody>
                                     <tr>
-                                        <td colSpan="2" style={{textAlign: "left"}}>{deposit_address_fragment}</td>
+                                        <td>{deposit_address_fragment}</td>
                                     </tr>
                                     {deposit_memo ? (
                                     <tr>
-                                        <td>memo:</td>
-                                        <td style={{textAlign: "left"}}>{deposit_memo}</td>
+                                        <td>memo: {deposit_memo}</td>
                                     </tr>) : null}
                                 </tbody>
                             </table>

--- a/web/app/components/DepositWithdraw/blocktrades/ConvertModalBlocktrades.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/ConvertModalBlocktrades.jsx
@@ -3,8 +3,6 @@ import Trigger from "react-foundation-apps/src/trigger";
 import Translate from "react-translate-component";
 import ChainTypes from "components/Utility/ChainTypes";
 import BindToChainState from "components/Utility/BindToChainState";
-import utils from "common/utils";
-import SettingsActions from "actions/SettingsActions";
 import BalanceComponent from "components/Utility/BalanceComponent";
 import counterpart from "counterpart";
 import AmountSelector from "components/Utility/AmountSelector";
@@ -26,30 +24,8 @@ class ConvertModalBlocktrades extends React.Component {
     constructor( props ) {
         super(props);
 		
-        fetch(this.props.url + '/wallets/' + this.props.output_wallet_type + '/address-validator?address=' + encodeURIComponent(localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : ''),
-            {
-            method: 'get',
-            headers: new Headers({"Accept": "application/json"})
-            }).then(reply => { reply.json().then( json =>
-            {
-                // only process it if the user hasn't changed the address
-                // since we initiated the request
-                if (this.state.convert_address === localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : '')
-                {
-                    this.setState(
-                    {
-                    convert_address_check_in_progress: false,
-                    convert_address_is_valid: json.isValid
-                    });
-                }
-            })});
-		
         this.state = {
-        convert_amount: null,
-        convert_address: localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : '',
-        convert_address_check_in_progress: true,
-		convert_address_is_valid: null,
-		convert_address_selected: localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : ''
+        convert_amount: null
         }
     }
 
@@ -57,44 +33,11 @@ class ConvertModalBlocktrades extends React.Component {
         this.setState( {convert_amount: amount} );
     }
 
-    onConvertAddressChanged( e ) {
-
-        let new_convert_address = e.target.value.trim();
-
-        fetch(this.props.url + '/wallets/' + this.props.output_wallet_type + '/address-validator?address=' + encodeURIComponent(new_convert_address),
-            {
-            method: 'get',
-            headers: new Headers({"Accept": "application/json"})
-            }).then(reply => { reply.json().then( json =>
-            {
-                // only process it if the user hasn't changed the address
-                // since we initiated the request
-                if (this.state.convert_address === new_convert_address)
-                {
-                this.setState(
-                    {
-                    convert_address_check_in_progress: false,
-                    convert_address_is_valid: json.isValid
-                    });
-                }
-            })});
-
-            this.setState( 
-            {
-            convert_address: new_convert_address,
-            convert_address_check_in_progress: true,
-			convert_address_selected: new_convert_address,
-            convert_address_is_valid: null
-            });
-    }
-
-    onSubmit() { 
+    onSubmit() {
 
 	}
 
-    render() {		
-	
-	    let {convert_address_selected} = this.state;
+    render() {
 
         let balance = null;
         let account_balances = this.props.account.get("balances").toJS();
@@ -108,15 +51,6 @@ class ConvertModalBlocktrades extends React.Component {
                 balance = "No funds";
         } else {
             balance = "No funds";
-        }
-       
-        let invalid_address_message = null;
-	   
-        if (!this.state.convert_address_check_in_progress && this.state.convert_address && this.state.convert_address.length)
-        {
-            if (!this.state.convert_address_is_valid) {
-				invalid_address_message = <div className="has-error" style={{paddingTop: 10}}><Translate content="gateway.valid_address" coin_type={this.props.output_coin_type} /></div>;
-		    }
         }
 	   
 	    let tabIndex = 1;
@@ -135,13 +69,6 @@ class ConvertModalBlocktrades extends React.Component {
                         onChange={this.onConvertAmountChange.bind(this)}
                         display_balance={balance}
                     />
-                </div>
-                <div className="content-block">
-                    <label><Translate component="span" content="modal.convert.address"/></label> 
-					<div className="inline-label">
-						<input type="text" value={convert_address_selected} tabIndex="4" onChange = {this.onConvertAddressChanged.bind(this)} autoComplete="off" />
-					</div>
-					{invalid_address_message}                
                 </div>
                 <div className="content-block">
                     <input type="submit" className="button" 

--- a/web/app/components/DepositWithdraw/blocktrades/ConvertModalBlocktrades.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/ConvertModalBlocktrades.jsx
@@ -18,7 +18,8 @@ class ConvertModalBlocktrades extends React.Component {
         output_coin_symbol: React.PropTypes.string.isRequired,
         output_coin_type: React.PropTypes.string.isRequired,
         url: React.PropTypes.string,
-        output_wallet_type: React.PropTypes.string
+        output_wallet_type: React.PropTypes.string,
+		conversion_memo: React.PropTypes.string
     };
 
     constructor( props ) {
@@ -38,7 +39,7 @@ class ConvertModalBlocktrades extends React.Component {
 	}
 
     render() {
-
+	
         let balance = null;
         let account_balances = this.props.account.get("balances").toJS();
         let asset_types = Object.keys(account_balances);

--- a/web/app/components/DepositWithdraw/blocktrades/ConvertModalBlocktrades.jsx
+++ b/web/app/components/DepositWithdraw/blocktrades/ConvertModalBlocktrades.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+import Trigger from "react-foundation-apps/src/trigger";
+import Translate from "react-translate-component";
+import ChainTypes from "components/Utility/ChainTypes";
+import BindToChainState from "components/Utility/BindToChainState";
+import utils from "common/utils";
+import SettingsActions from "actions/SettingsActions";
+import BalanceComponent from "components/Utility/BalanceComponent";
+import counterpart from "counterpart";
+import AmountSelector from "components/Utility/AmountSelector";
+
+@BindToChainState({keep_updating:true})
+class ConvertModalBlocktrades extends React.Component {
+
+    static propTypes = {
+        account: ChainTypes.ChainAccount.isRequired,
+        issuer: ChainTypes.ChainAccount.isRequired,
+        asset: ChainTypes.ChainAsset.isRequired, 
+        output_coin_name: React.PropTypes.string.isRequired,
+        output_coin_symbol: React.PropTypes.string.isRequired,
+        output_coin_type: React.PropTypes.string.isRequired,
+        url: React.PropTypes.string,
+        output_wallet_type: React.PropTypes.string
+    };
+
+    constructor( props ) {
+        super(props);
+		
+        fetch(this.props.url + '/wallets/' + this.props.output_wallet_type + '/address-validator?address=' + encodeURIComponent(localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : ''),
+            {
+            method: 'get',
+            headers: new Headers({"Accept": "application/json"})
+            }).then(reply => { reply.json().then( json =>
+            {
+                // only process it if the user hasn't changed the address
+                // since we initiated the request
+                if (this.state.convert_address === localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : '')
+                {
+                    this.setState(
+                    {
+                    convert_address_check_in_progress: false,
+                    convert_address_is_valid: json.isValid
+                    });
+                }
+            })});
+		
+        this.state = {
+        convert_amount: null,
+        convert_address: localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : '',
+        convert_address_check_in_progress: true,
+		convert_address_is_valid: null,
+		convert_address_selected: localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) !== null ? localStorage.getItem(`history_address_last_${this.props.output_wallet_type}`) : ''
+        }
+    }
+
+    onConvertAmountChange( {amount, asset} ) {
+        this.setState( {convert_amount: amount} );
+    }
+
+    onConvertAddressChanged( e ) {
+
+        let new_convert_address = e.target.value.trim();
+
+        fetch(this.props.url + '/wallets/' + this.props.output_wallet_type + '/address-validator?address=' + encodeURIComponent(new_convert_address),
+            {
+            method: 'get',
+            headers: new Headers({"Accept": "application/json"})
+            }).then(reply => { reply.json().then( json =>
+            {
+                // only process it if the user hasn't changed the address
+                // since we initiated the request
+                if (this.state.convert_address === new_convert_address)
+                {
+                this.setState(
+                    {
+                    convert_address_check_in_progress: false,
+                    convert_address_is_valid: json.isValid
+                    });
+                }
+            })});
+
+            this.setState( 
+            {
+            convert_address: new_convert_address,
+            convert_address_check_in_progress: true,
+			convert_address_selected: new_convert_address,
+            convert_address_is_valid: null
+            });
+    }
+
+    onSubmit() { 
+
+	}
+
+    render() {		
+	
+	    let {convert_address_selected} = this.state;
+
+        let balance = null;
+        let account_balances = this.props.account.get("balances").toJS();
+        let asset_types = Object.keys(account_balances);
+
+        if (asset_types.length > 0) {
+            let current_asset_id = this.props.asset.get('id');
+            if( current_asset_id )
+                balance = (<span><Translate component="span" content="transfer.available"/>: <BalanceComponent balance={account_balances[current_asset_id]}/></span>)
+            else
+                balance = "No funds";
+        } else {
+            balance = "No funds";
+        }
+       
+        let invalid_address_message = null;
+	   
+        if (!this.state.convert_address_check_in_progress && this.state.convert_address && this.state.convert_address.length)
+        {
+            if (!this.state.convert_address_is_valid) {
+				invalid_address_message = <div className="has-error" style={{paddingTop: 10}}><Translate content="gateway.valid_address" coin_type={this.props.output_coin_type} /></div>;
+		    }
+        }
+	   
+	    let tabIndex = 1;
+
+        return (<form className="grid-block vertical full-width-content">
+            <div className="grid-container">
+                <div className="content-block">
+                    <h3><Translate content="gateway.convert_coin" coin={this.props.output_coin_name} symbol={this.props.output_coin_symbol} /></h3>
+                </div>
+                <div className="content-block">
+                    <AmountSelector label="modal.convert.amount" 
+                        amount={this.state.convert_amount}
+                        asset={this.props.asset.get('id')}
+                        assets={[this.props.asset.get('id')]}
+                        placeholder="0.0"
+                        onChange={this.onConvertAmountChange.bind(this)}
+                        display_balance={balance}
+                    />
+                </div>
+                <div className="content-block">
+                    <label><Translate component="span" content="modal.convert.address"/></label> 
+					<div className="inline-label">
+						<input type="text" value={convert_address_selected} tabIndex="4" onChange = {this.onConvertAddressChanged.bind(this)} autoComplete="off" />
+					</div>
+					{invalid_address_message}                
+                </div>
+                <div className="content-block">
+                    <input type="submit" className="button" 
+                    onClick={this.onSubmit.bind(this)} 
+                    value={counterpart.translate("modal.convert.submit")} />
+                    <Trigger close={this.props.modal_id}>
+                        <a href className="secondary button"><Translate content="account.perm.cancel" /></a>
+                    </Trigger>
+                </div>
+            </div> 
+            </form>
+	    )
+    }  
+};
+
+export default ConvertModalBlocktrades;


### PR DESCRIPTION
* Allow users to convert between BitShares asset types (e.g. BTS -> BITUSD) using the BlockTrades bridge on the Deposit/Withdraw page. 
* Remember the last output coin type the user selected in the bridge for each input coin type, and provide a sensible default (BTC instead of AGRS) if they have never selected an output coin type before.  This will help prevent a common user mistake.
* Fix a display bug that was clipping deposit addresses for the gateways